### PR TITLE
cleaned up delete statement (less repetative)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,5 +14,5 @@ mv book.pdf Consumer-Centric\ API\ Design\ `git describe --abbrev=0`.pdf
 
 # run `./build.sh --perserve` if you want to keep these files around
 if [ "$1" != "--preserve" ]; then
-    rm book.aux book.bbl book.blg book.log book.out book.toc
+    rm -f book.{aux,bbl,blg,log,out,toc}
 fi


### PR DESCRIPTION
Also used `-f` on `rm`, so a missing file will not cancel the deltion of
all other files.
